### PR TITLE
Fix AsyncWebServer when building for Arduino SDK 2.0.0-rc1

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -184,10 +184,14 @@ void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage)
     delete dataMessage;
     return;
   }
-
-  _messageQueue.add(dataMessage);
-
-  _runQueue();
+  if(_messageQueue.length() >= SSE_MAX_QUEUED_MESSAGES){
+      ets_printf("ERROR: Too many messages queued\n");
+      delete dataMessage;
+  } else {
+      _messageQueue.add(dataMessage);
+  }
+  if(_client->canSend())
+    _runQueue();
 }
 
 void AsyncEventSourceClient::_onAck(size_t len, uint32_t time){

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -23,10 +23,27 @@
 #include <Arduino.h>
 #ifdef ESP32
 #include <AsyncTCP.h>
+#define SSE_MAX_QUEUED_MESSAGES 32
 #else
 #include <ESPAsyncTCP.h>
+#define SSE_MAX_QUEUED_MESSAGES 8
 #endif
 #include <ESPAsyncWebServer.h>
+
+#include "AsyncWebSynchronization.h"
+
+#ifdef ESP8266
+#include <Hash.h>
+#ifdef CRYPTO_HASH_h // include Hash.h from espressif framework if the first include was from the crypto library
+#include <../src/Hash.h>
+#endif
+#endif
+
+#ifdef ESP32
+#define DEFAULT_MAX_SSE_CLIENTS 8
+#else
+#define DEFAULT_MAX_SSE_CLIENTS 4
+#endif
 
 class AsyncEventSource;
 class AsyncEventSourceResponse;

--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -41,7 +41,9 @@
 #if ARDUINOJSON_VERSION_MAJOR == 5
   #define ARDUINOJSON_5_COMPATIBILITY
 #else
-  #define DYNAMIC_JSON_DOCUMENT_SIZE  1024
+  #ifndef DYNAMIC_JSON_DOCUMENT_SIZE
+    #define DYNAMIC_JSON_DOCUMENT_SIZE  1024
+  #endif
 #endif
 
 constexpr const char* JSON_MIMETYPE = "application/json";

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -24,18 +24,7 @@
 #include <libb64/cencode.h>
 
 #ifndef ESP8266
-extern "C" {
-typedef struct {
-    uint32_t state[5];
-    uint32_t count[2];
-    unsigned char buffer[64];
-} SHA1_CTX;
-
-void SHA1Transform(uint32_t state[5], const unsigned char buffer[64]);
-void SHA1Init(SHA1_CTX* context);
-void SHA1Update(SHA1_CTX* context, const unsigned char* data, uint32_t len);
-void SHA1Final(unsigned char digest[20], SHA1_CTX* context);
-}
+#include "mbedtls/sha1.h"
 #else
 #include <Hash.h>
 #endif
@@ -1268,10 +1257,12 @@ AsyncWebSocketResponse::AsyncWebSocketResponse(const String& key, AsyncWebSocket
   sha1(key + WS_STR_UUID, hash);
 #else
   (String&)key += WS_STR_UUID;
-  SHA1_CTX ctx;
-  SHA1Init(&ctx);
-  SHA1Update(&ctx, (const unsigned char*)key.c_str(), key.length());
-  SHA1Final(hash, &ctx);
+  mbedtls_sha1_context ctx;
+  mbedtls_sha1_init(&ctx);
+  mbedtls_sha1_starts_ret(&ctx);
+  mbedtls_sha1_update_ret(&ctx, (const unsigned char*)key.c_str(), key.length());
+  mbedtls_sha1_finish_ret(&ctx, hash);
+  mbedtls_sha1_free(&ctx);
 #endif
   base64_encodestate _state;
   base64_init_encodestate(&_state);

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -829,7 +829,7 @@ void AsyncWebSocketClient::binary(AsyncWebSocketMessageBuffer * buffer)
 
 IPAddress AsyncWebSocketClient::remoteIP() {
     if(!_client) {
-        return IPAddress(0U);
+        return IPAddress((uint32_t)0);
     }
     return _client->remoteIP();
 }

--- a/src/WebAuthentication.cpp
+++ b/src/WebAuthentication.cpp
@@ -71,9 +71,9 @@ static bool getMD5(uint8_t * data, uint16_t len, char * output){//33 bytes or mo
   memset(_buf, 0x00, 16);
 #ifdef ESP32
   mbedtls_md5_init(&_ctx);
-  mbedtls_md5_starts(&_ctx);
-  mbedtls_md5_update(&_ctx, data, len);
-  mbedtls_md5_finish(&_ctx, _buf);
+  mbedtls_md5_starts_ret(&_ctx);
+  mbedtls_md5_update_ret(&_ctx, data, len);
+  mbedtls_md5_finish_ret(&_ctx, _buf);
 #else
   MD5Init(&_ctx);
   MD5Update(&_ctx, data, len);

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -119,16 +119,22 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
     }
   
     virtual void handleRequest(AsyncWebServerRequest *request) override final {
+      if((_username != "" && _password != "") && !request->authenticate(_username.c_str(), _password.c_str()))
+        return request->requestAuthentication();
       if(_onRequest)
         _onRequest(request);
       else
         request->send(500);
     }
     virtual void handleUpload(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final) override final {
+      if((_username != "" && _password != "") && !request->authenticate(_username.c_str(), _password.c_str()))
+        return request->requestAuthentication();
       if(_onUpload)
         _onUpload(request, filename, index, data, len, final);
     }
     virtual void handleBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) override final {
+      if((_username != "" && _password != "") && !request->authenticate(_username.c_str(), _password.c_str()))
+        return request->requestAuthentication();
       if(_onBody)
         _onBody(request, data, len, index, total);
     }

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -105,6 +105,13 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
         }
       } else 
 #endif
+      if (_uri.length() && _uri.startsWith("/*.")) {
+         String uriTemplate = String (_uri);
+         uriTemplate = uriTemplate.substring(uriTemplate.lastIndexOf("."));
+         if (!request->url().endsWith(uriTemplate))
+           return false;
+      }
+      else
       if (_uri.length() && _uri.endsWith("*")) {
         String uriTemplate = String(_uri);
 	uriTemplate = uriTemplate.substring(0, uriTemplate.length() - 1);


### PR DESCRIPTION
This allows to build against latest Arduino SDK 2.0.0-rc1 for ESP32/ESP32-C3 by fixing two build-time issue: One issue related to type differences (fixed by explicit type cast) and by not using deprecated mbedtls functions.

It also fixes a use-after-free issue when iterating over HTTP heather, which lead to a crash on RISC-V based ESP32-C3 (fixes https://github.com/esphome/issues/issues/2257). This issue is not specific to RISC-V, but seems not lead to a crash on Xtensa based CPUs so far.