### PR TITLE
Don't delete handlers when they're removed

### DIFF
--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -32,8 +32,8 @@ bool ON_AP_FILTER(AsyncWebServerRequest *request) {
 
 AsyncWebServer::AsyncWebServer(uint16_t port)
   : _server(port)
-  , _rewrites(LinkedList<AsyncWebRewrite*>([](AsyncWebRewrite* r){ delete r; }))
-  , _handlers(LinkedList<AsyncWebHandler*>([](AsyncWebHandler* h){ delete h; }))
+  , _rewrites(LinkedList<AsyncWebRewrite*>(nullptr))
+  , _handlers(LinkedList<AsyncWebHandler*>(nullptr))
 {
   _catchAllHandler = new AsyncCallbackWebHandler();
   if(_catchAllHandler == NULL)


### PR DESCRIPTION
This was an utterly idiotic API; if you accept pointers, you can't just assume ownership over them and unconditionally destroy them whenever you like too.

This broke the captive portal: when it stopped, it deinitialized the webserver, which deleted its handlers. As the captive portal object itself was one of the handlers, it and its member objects were now destroyed, and that caused its own continuing teardown to use-after-free or double-free (see esphome/esphome#2686). 