### PR TITLE
Adapt for LibreTuya compatibility

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
   "version": "2.1.0",
   "license": "LGPL-3.0",
   "frameworks": "arduino",
-  "platforms": ["espressif8266", "espressif32"],
+  "platforms": ["espressif8266", "espressif32", "libretuya"],
   "dependencies": [
     {
       "owner": "ottowinter",
@@ -25,7 +25,7 @@
     {
       "owner": "esphome",
       "name": "AsyncTCP-esphome",
-      "platforms": "espressif32"
+      "platforms": ["espressif32", "libretuya"]
     },
     {
       "name": "Hash",

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -22,7 +22,7 @@
 
 #include <Arduino.h>
 #include <Arduino.h>
-#ifdef ESP32
+#if defined(ESP32) || defined(LIBRETUYA)
 #include <AsyncTCP.h>
 #else
 #include <ESPAsyncTCP.h>
@@ -43,7 +43,7 @@
 #endif
 #endif
 
-#ifdef ESP32
+#if defined(ESP32) || defined(LIBRETUYA)
 #define DEFAULT_MAX_SSE_CLIENTS 8
 #else
 #define DEFAULT_MAX_SSE_CLIENTS 4

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -25,6 +25,7 @@
 
 #ifndef ESP8266
 #include "mbedtls/sha1.h"
+#include "mbedtls/version.h"
 #else
 #include <Hash.h>
 #endif
@@ -1256,9 +1257,15 @@ AsyncWebSocketResponse::AsyncWebSocketResponse(const String& key, AsyncWebSocket
   (String&)key += WS_STR_UUID;
   mbedtls_sha1_context ctx;
   mbedtls_sha1_init(&ctx);
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
   mbedtls_sha1_starts_ret(&ctx);
   mbedtls_sha1_update_ret(&ctx, (const unsigned char*)key.c_str(), key.length());
   mbedtls_sha1_finish_ret(&ctx, hash);
+#else
+  mbedtls_sha1_starts(&ctx);
+  mbedtls_sha1_update(&ctx, (const unsigned char*)key.c_str(), key.length());
+  mbedtls_sha1_finish(&ctx, hash);
+#endif
   mbedtls_sha1_free(&ctx);
 #endif
   base64_encodestate _state;

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -22,7 +22,7 @@
 #define ASYNCWEBSOCKET_H_
 
 #include <Arduino.h>
-#ifdef ESP32
+#if defined(ESP32) || defined(LIBRETUYA)
 #include <AsyncTCP.h>
 #define WS_MAX_QUEUED_MESSAGES 32
 #else
@@ -40,7 +40,7 @@
 #endif
 #endif
 
-#ifdef ESP32
+#if defined(ESP32) || defined(LIBRETUYA)
 #define DEFAULT_MAX_WS_CLIENTS 8
 #else
 #define DEFAULT_MAX_WS_CLIENTS 4

--- a/src/AsyncWebSynchronization.h
+++ b/src/AsyncWebSynchronization.h
@@ -5,7 +5,7 @@
 
 #include <ESPAsyncWebServer.h>
 
-#ifdef ESP32
+#if defined(ESP32) || (defined(LIBRETUYA) && LT_HAS_FREERTOS)
 
 // This is the ESP32 version of the Sync Lock, using the FreeRTOS Semaphore
 class AsyncWebLock

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -28,7 +28,7 @@
 
 #include "StringArray.h"
 
-#ifdef ESP32
+#if defined(ESP32) || defined(LIBRETUYA)
 #include <WiFi.h>
 #include <AsyncTCP.h>
 #elif defined(ESP8266)


### PR DESCRIPTION
(see [esphome#3509](https://github.com/esphome/esphome/pull/3509))

This also fixes changed SHA1 method names for latest (and older than 2.7) mbedTLS.