### PR TITLE
Fix usage after free in AsyncEventSource

### DIFF
--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/esphome/ESPAsyncWebServer.git"
   },
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "LGPL-3.0",
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32", "libretuya"],

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -189,8 +189,8 @@ void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage)
     return;
   }
 
-  AsyncWebLockGuard l(_lock);
   {
+    AsyncWebLockGuard l(_lock);
     if(_messageQueue.length() < SSE_MAX_QUEUED_MESSAGES){
       _messageQueue.add(dataMessage);
       if(_client->canSend())

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -76,6 +76,7 @@ class AsyncEventSourceClient {
     AsyncEventSource *_server;
     uint32_t _lastId;
     LinkedList<AsyncEventSourceMessage *> _messageQueue;
+    AsyncWebLock _lock;
     void _queueMessage(AsyncEventSourceMessage *dataMessage);
     void _runQueue();
 


### PR DESCRIPTION
Queue inside AsyncEventSourceClient is executed from 2 threads without locking which may lead to use after free. There is more issues in ESPAsyncWebServer and AsyncTCP-esphome. Having 2 threads seems to be good idea since it helps with making web interface more interactive but now it may crash esp32.