### PR TITLE
Allow user customization WS_MAX_QUEUED_MESSAGES

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -102,7 +102,7 @@ size_t webSocketSendFrame(AsyncClient *client, bool final, uint8_t opcode, bool 
       return 0;
     }
   }
-  client->send();
+  if (!client->send();) return 0;
   return len;
 }
 

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -24,10 +24,14 @@
 #include <Arduino.h>
 #if defined(ESP32) || defined(LIBRETUYA)
 #include <AsyncTCP.h>
+#ifndef WS_MAX_QUEUED_MESSAGES
 #define WS_MAX_QUEUED_MESSAGES 32
+#endif
 #else
 #include <ESPAsyncTCP.h>
+#ifndef WS_MAX_QUEUED_MESSAGES
 #define WS_MAX_QUEUED_MESSAGES 8
+#endif
 #endif
 #include <ESPAsyncWebServer.h>
 


### PR DESCRIPTION
Since I recently received an email about this issue, I realized that some users send short messages that require a long queue, and I thought the user should be given the ability to customize (in cases where they know what they are doing Down).