### PR TITLE
Fix: erroneous semicolon

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -102,7 +102,7 @@ size_t webSocketSendFrame(AsyncClient *client, bool final, uint8_t opcode, bool 
       return 0;
     }
   }
-  if (!client->send();) return 0;
+  if (!client->send()) return 0;
   return len;
 }
 


### PR DESCRIPTION
Fixes error: `ESPAsyncWebServer-esphome/src/AsyncWebSocket.cpp:105:23: error: expected primary-expression before ')' token`