### PR TITLE
Allow arbitrary user data

### DIFF
--- a/examples/user_data/user_data.ino
+++ b/examples/user_data/user_data.ino
@@ -1,0 +1,77 @@
+//
+// A simple server implementation showing how to:
+//  * serve arbitrary user data
+//
+
+#include <Arduino.h>
+#ifdef ESP32
+#include <WiFi.h>
+#include <AsyncTCP.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#include <ESPAsyncTCP.h>
+#endif
+#include <ESPAsyncWebServer.h>
+
+#include <string>
+#include <vector>
+
+AsyncWebServer server(80);
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+const std::vector<std::string> tokens {
+    "Hello", " ", "World", "!"
+};
+
+void setup() {
+
+    Serial.begin(115200);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(ssid, password);
+    if (WiFi.waitForConnectResult() != WL_CONNECTED) {
+        Serial.printf("WiFi Failed!\n");
+        return;
+    }
+
+    Serial.print("IP Address: ");
+    Serial.println(WiFi.localIP());
+
+    server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+        AsyncWebServerResponse *response = request->beginUserDataResponse("text/plain", [&](uint8_t *buffer, size_t maxLen, std::any& userData) -> size_t {
+            // If user data is not set yet, we start with index 0 and try again
+            if (!userData.has_value()) {
+                userData = (size_t)0;
+                return RESPONSE_TRY_AGAIN;
+            } else if (std::any_cast<size_t>(userData) >= tokens.size()) {
+                return 0;
+            }
+            // Write up to "maxLen" bytes into "buffer" and return the amount written.
+            // You will be asked for more data until 0 is returned
+            size_t i = std::any_cast<size_t>(userData);
+            const size_t tokenSize = tokens.at(i).size();
+            if (tokenSize > maxLen) {
+                std::cout << "token " << i << " with length: " << tokenSize << " exceeds max length: " << maxLen << std::endl;
+                return 0;
+            }
+
+            size_t bytesWritten = 0;
+            while (i < tokens.size() && (bytesWritten + tokens.at(i).size()) <= maxLen) {
+                const auto& token = tokens.at(i);
+                std::memcpy(buffer + bytesWritten, token.c_str(), token.size());
+                bytesWritten += token.size();
+                ++i;
+            }
+
+            userData = i;
+            return bytesWritten;
+        });
+        request->send(response);
+    });
+
+    server.begin();
+}
+
+void loop() {
+}

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -23,6 +23,7 @@
 
 #include "Arduino.h"
 
+#include <any>
 #include <functional>
 #include "FS.h"
 
@@ -129,6 +130,7 @@ class AsyncWebHeader {
 typedef enum { RCT_NOT_USED = -1, RCT_DEFAULT = 0, RCT_HTTP, RCT_WS, RCT_EVENT, RCT_MAX } RequestedConnectionType;
 
 typedef std::function<size_t(uint8_t*, size_t, size_t)> AwsResponseFiller;
+typedef std::function<size_t(uint8_t*, size_t, std::any&)> AwsUserDataFiller;
 typedef std::function<String(const String&)> AwsTemplateProcessor;
 
 class AsyncWebServerRequest {
@@ -249,6 +251,7 @@ class AsyncWebServerRequest {
     AsyncWebServerResponse *beginResponse(Stream &stream, const String& contentType, size_t len, AwsTemplateProcessor callback=nullptr);
     AsyncWebServerResponse *beginResponse(const String& contentType, size_t len, AwsResponseFiller callback, AwsTemplateProcessor templateCallback=nullptr);
     AsyncWebServerResponse *beginChunkedResponse(const String& contentType, AwsResponseFiller callback, AwsTemplateProcessor templateCallback=nullptr);
+    AsyncWebServerResponse *beginUserDataResponse(const String& contentType, AwsUserDataFiller callback);
     AsyncResponseStream *beginResponseStream(const String& contentType, size_t bufferSize=1460);
     AsyncWebServerResponse *beginResponse_P(int code, const String& contentType, const uint8_t * content, size_t len, AwsTemplateProcessor callback=nullptr);
     AsyncWebServerResponse *beginResponse_P(int code, const String& contentType, PGM_P content, AwsTemplateProcessor callback=nullptr);

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -756,6 +756,10 @@ AsyncWebServerResponse * AsyncWebServerRequest::beginChunkedResponse(const Strin
   return new AsyncCallbackResponse(contentType, 0, callback, templateCallback);
 }
 
+AsyncWebServerResponse * AsyncWebServerRequest::beginUserDataResponse(const String& contentType, AwsUserDataFiller callback){
+  return new AsyncUserDataResponse(contentType, callback);
+}
+
 AsyncResponseStream * AsyncWebServerRequest::beginResponseStream(const String& contentType, size_t bufferSize){
   return new AsyncResponseStream(contentType, bufferSize);
 }

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -26,6 +26,7 @@
 #undef min
 #undef max
 #endif
+#include <any>
 #include <vector>
 // It is possible to restore these defines, but one can use _min and _max instead. Or std::min, std::max.
 
@@ -104,6 +105,16 @@ class AsyncChunkedResponse: public AsyncAbstractResponse {
     size_t _filledLength;
   public:
     AsyncChunkedResponse(const String& contentType, AwsResponseFiller callback, AwsTemplateProcessor templateCallback=nullptr);
+    bool _sourceValid() const { return !!(_content); }
+    virtual size_t _fillBuffer(uint8_t *buf, size_t maxLen) override;
+};
+
+class AsyncUserDataResponse: public AsyncAbstractResponse {
+  private:
+    AwsUserDataFiller _content;
+    std::any _userData;
+  public:
+    AsyncUserDataResponse(const String& contentType, AwsUserDataFiller callback);
     bool _sourceValid() const { return !!(_content); }
     virtual size_t _fillBuffer(uint8_t *buf, size_t maxLen) override;
 };

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -638,6 +638,23 @@ size_t AsyncChunkedResponse::_fillBuffer(uint8_t *data, size_t len){
 }
 
 /*
+ * User Data Response
+ * */
+
+AsyncUserDataResponse::AsyncUserDataResponse(const String& contentType, AwsUserDataFiller callback): AsyncAbstractResponse() {
+  _code = 200;
+  _content = callback;
+  _contentLength = 0;
+  _contentType = contentType;
+  _sendContentLength = false;
+  _chunked = true;
+}
+
+size_t AsyncUserDataResponse::_fillBuffer(uint8_t *data, size_t len){
+  return _content(data, len, _userData);
+}
+
+/*
  * Progmem Response
  * */
 


### PR DESCRIPTION
Hi there,

since the regular chunked response was not enough for me (because my chunks are randomly placed in memory), I added some functionality to be able to feed some user data to the filler class (an index in my case. written bytes would not be enough).
Please check out the example what this change allows you to do.

Hopefully, this is interesting for you.

Best regards
Manuel