### PR TITLE
Bug safari with Content-Encoding: gzip and Content-Disposition

### DIFF
--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -535,7 +535,7 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String& path, const String& c
     // set filename and force rendering
     snprintf(buf, sizeof (buf), "inline; filename=\"%s\"", filename);
   }
-  addHeader("Content-Disposition", buf);
+  // addHeader("Content-Disposition", buf);  
 }
 
 AsyncFileResponse::AsyncFileResponse(File content, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback): AsyncAbstractResponse(callback){
@@ -566,7 +566,7 @@ AsyncFileResponse::AsyncFileResponse(File content, const String& path, const Str
   } else {
     snprintf(buf, sizeof (buf), "inline; filename=\"%s\"", filename);
   }
-  addHeader("Content-Disposition", buf);
+  //addHeader("Content-Disposition", buf);
 }
 
 size_t AsyncFileResponse::_fillBuffer(uint8_t *data, size_t len){


### PR DESCRIPTION
hi, 

the header Content-Disposition create a bug in this case : 
explorer : Safari 

html page called in mode gzip ( HTTP compress ) 
( 
GET /index.html HTTP/1.1
Host: xxx 
Accept-Encoding: gzip ) 

the librairie return a wrong"Content-Disposition" and expose a file who was not rerouted 
ex : 
`   
void compress_html(AsyncWebServerRequest *request,String filefs , String format ) {
      AsyncWebServerResponse *response = request->beginResponse(SPIFFS, filefs, format);
      response->addHeader("Content-Encoding", "gzip");
      response->addHeader("Cache-Control", "max-age=604800");
      request->send(response);
}

 server.on("/",HTTP_GET, [](AsyncWebServerRequest *request){
    if(SPIFFS.exists("/index.html.gz")){
      compress_html(request,"/index-ap.html.gz", "text/html");
    }`

the response header is wrong 
Accept-Ranges: none
Cache-Control: max-age=604800
Connection: close
Content-Disposition: inline; filename="index.html.gz"
Content-Encoding: gzip
Content-Length: 3890
Content-Type: text/html

and Content-Disposition: is not usefull in this case. 

on all navigator except safari, the navigator  skip this line.  Safari try to call the wrong file. 