### PR TITLE
RP2040: Add support for the RP2040.

### DIFF
--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -24,6 +24,8 @@
 #include <Arduino.h>
 #if defined(ESP32) || defined(LIBRETUYA)
 #include <AsyncTCP.h>
+#elif defined(USE_RP2040)
+#include <AsyncTCP_RP2040W.h>
 #else
 #include <ESPAsyncTCP.h>
 #endif

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -24,8 +24,13 @@
 #include <libb64/cencode.h>
 
 #ifndef ESP8266
+#if defined(USE_RP2040)
+#include "bearssl/bearssl.h"
+#include "bearssl/bearssl_hash.h"
+#else
 #include "mbedtls/sha1.h"
 #include "mbedtls/version.h"
+#endif
 #else
 #include <Hash.h>
 #endif
@@ -1253,6 +1258,12 @@ AsyncWebSocketResponse::AsyncWebSocketResponse(const String& key, AsyncWebSocket
   }
 #ifdef ESP8266
   sha1(key + WS_STR_UUID, hash);
+#elif defined(USE_RP2040)
+  (String&)key += WS_STR_UUID;
+  br_sha1_context ctx;
+  br_sha1_init(&ctx);
+  br_sha1_update(&ctx, (const unsigned char*)key.c_str(), key.length());
+  br_sha1_out(&ctx, hash);
 #else
   (String&)key += WS_STR_UUID;
   mbedtls_sha1_context ctx;

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -27,6 +27,12 @@
 #ifndef WS_MAX_QUEUED_MESSAGES
 #define WS_MAX_QUEUED_MESSAGES 32
 #endif
+#elif defined(USE_RP2040)
+#include <AsyncTCP_RP2040W.h>
+#ifndef WS_MAX_QUEUED_MESSAGES
+#define WS_MAX_QUEUED_MESSAGES 8
+#endif
+#define ets_printf(msg) void()
 #else
 #include <ESPAsyncTCP.h>
 #ifndef WS_MAX_QUEUED_MESSAGES

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -34,6 +34,9 @@
 #elif defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <ESPAsyncTCP.h>
+#elif defined(USE_RP2040)
+#include <WiFi.h>
+#include <AsyncTCP_RP2040W.h>
 #else
 #error Platform not supported
 #endif

--- a/src/WebAuthentication.cpp
+++ b/src/WebAuthentication.cpp
@@ -22,6 +22,8 @@
 #include <libb64/cencode.h>
 #ifdef ESP32
 #include "mbedtls/md5.h"
+#elif defined(USE_RP2040)
+#include <MD5Builder.h>
 #else
 #include "md5.h"
 #endif
@@ -61,6 +63,8 @@ bool checkBasicAuthentication(const char * hash, const char * username, const ch
 static bool getMD5(uint8_t * data, uint16_t len, char * output){//33 bytes or more
 #ifdef ESP32
     mbedtls_md5_context _ctx;
+#elif defined(USE_RP2040)
+    br_md5_context _ctx;
 #else
     md5_context_t _ctx;
 #endif
@@ -74,6 +78,10 @@ static bool getMD5(uint8_t * data, uint16_t len, char * output){//33 bytes or mo
   mbedtls_md5_starts_ret(&_ctx);
   mbedtls_md5_update_ret(&_ctx, data, len);
   mbedtls_md5_finish_ret(&_ctx, _buf);
+#elif defined(USE_RP2040)
+  br_md5_init(&_ctx);
+  br_md5_update(&_ctx, data, len);
+  br_md5_state(&_ctx, _buf);
 #else
   MD5Init(&_ctx);
   MD5Update(&_ctx, data, len);


### PR DESCRIPTION
P2040: Add support for the RP2040.

This patch is a small patch that adds in the required ifdefs to make the async web server work on the RP2040 platform.

It requires the use of the "AsyncTCP_RP2040W" package from here:
https://github.com/khoih-prog/AsyncTCP_RP2040W

This pull request is being done in tandem with the main pull request on esphome here:
https://github.com/esphome/esphome/pull/5305
