### PR TITLE
Add mutex for queue processing.

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -236,6 +236,10 @@ void AsyncEventSourceClient::send(const char *message, const char *event, uint32
 }
 
 void AsyncEventSourceClient::_runQueue(){
+  if(!this->_messageQueue_mutex.try_lock()) {
+    return;
+  }
+
   while(!_messageQueue.isEmpty() && _messageQueue.front()->finished()){
     _messageQueue.remove(_messageQueue.front());
   }
@@ -245,6 +249,7 @@ void AsyncEventSourceClient::_runQueue(){
     if(!(*i)->sent())
       (*i)->send(_client);
   }
+  this->_messageQueue_mutex.unlock();
 }
 
 

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -236,9 +236,16 @@ void AsyncEventSourceClient::send(const char *message, const char *event, uint32
 }
 
 void AsyncEventSourceClient::_runQueue(){
+#if defined(ESP32)
   if(!this->_messageQueue_mutex.try_lock()) {
     return;
   }
+#else
+  if(this->_messageQueue_processing){
+    return;
+  }
+  this->_messageQueue_processing = true;
+#endif // ESP32
 
   while(!_messageQueue.isEmpty() && _messageQueue.front()->finished()){
     _messageQueue.remove(_messageQueue.front());
@@ -249,7 +256,12 @@ void AsyncEventSourceClient::_runQueue(){
     if(!(*i)->sent())
       (*i)->send(_client);
   }
+
+#if defined(ESP32)
   this->_messageQueue_mutex.unlock();
+#else
+  this->_messageQueue_processing = false;
+#endif // ESP32
 }
 
 

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -28,6 +28,8 @@
 #include <ESPAsyncTCP.h>
 #endif
 
+#include <mutex>
+
 #ifndef SSE_MAX_QUEUED_MESSAGES
 #define SSE_MAX_QUEUED_MESSAGES 32
 #endif
@@ -75,6 +77,7 @@ class AsyncEventSourceClient {
     AsyncClient *_client;
     AsyncEventSource *_server;
     uint32_t _lastId;
+    std::mutex _messageQueue_mutex;
     LinkedList<AsyncEventSourceMessage *> _messageQueue;
     void _queueMessage(AsyncEventSourceMessage *dataMessage);
     void _runQueue();

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -28,7 +28,9 @@
 #include <ESPAsyncTCP.h>
 #endif
 
+#if defined(ESP32)
 #include <mutex>
+#endif // ESP32
 
 #ifndef SSE_MAX_QUEUED_MESSAGES
 #define SSE_MAX_QUEUED_MESSAGES 32
@@ -77,7 +79,11 @@ class AsyncEventSourceClient {
     AsyncClient *_client;
     AsyncEventSource *_server;
     uint32_t _lastId;
+#if defined(ESP32)
     std::mutex _messageQueue_mutex;
+#else
+    bool _messageQueue_processing;
+#endif // ESP32
     LinkedList<AsyncEventSourceMessage *> _messageQueue;
     void _queueMessage(AsyncEventSourceMessage *dataMessage);
     void _runQueue();


### PR DESCRIPTION
As part of <https://github.com/esphome/esphome/pull/5373> I identified that the method `AsyncEventSourceClient::_runQueue` is not multi threading safe.
Multiple threads sending messages will result in the same message being transmitted multiple times to the client.
This PR adds a mutex to prevent this.
