### PR TITLE
Guard against concurrent access of the queues when using multiple tasks

### DIFF
--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -164,6 +164,7 @@ class AsyncWebSocketClient {
     AsyncWebSocket *_server;
     uint32_t _clientId;
     AwsClientStatus _status;
+    AsyncWebLock _lock;
 
     LinkedList<AsyncWebSocketControl *> _controlQueue;
     LinkedList<AsyncWebSocketMessage *> _messageQueue;


### PR DESCRIPTION
I currently have some random crashes due to the fact that the queues in the WS implementation are accessed from different RTOS tasks. I've placed some locks today, now trying to run it for a while to see if it crashed again in the queue loop. So far, a few hours without crash.
I am pushing 1 or 2 ws events each second and the app can also react based on incoming ws events.
This seems to work but I am not sure if there is a more efficient way to fix that.

I've opened this PR as draft because I'd like to test it for a few days.

Code inspired by:
- https://github.com/me-no-dev/ESPAsyncWebServer/pull/887
- https://github.com/esphome/ESPAsyncWebServer/pull/24