### PR TITLE
Initialize _messageQueue_processing

### DIFF
--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -82,7 +82,7 @@ class AsyncEventSourceClient {
 #if defined(ESP32)
     std::mutex _messageQueue_mutex;
 #else
-    bool _messageQueue_processing;
+    bool _messageQueue_processing{false};
 #endif // ESP32
     LinkedList<AsyncEventSourceMessage *> _messageQueue;
     void _queueMessage(AsyncEventSourceMessage *dataMessage);


### PR DESCRIPTION
This is needed to fix ESPHome's web_server component for esp8266 per https://github.com/esphome/issues/issues/5793 and https://github.com/esphome/ESPAsyncWebServer/issues/30.  The _messageQueue_processing boolean is being initialized to true sometimes and locking up the events server.