### PR TITLE
Fixes for esp32-arduino 3.0 (and add library.properties)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=ESPAsyncWebServer
+version=3.1.0
+author=esphome
+maintainer=esphome
+sentence=Async Web Server for ESP8266 and ESP32
+paragraph=A fork of the ESPAsyncWebServer library maintained by ESPHome
+category=Communication
+url=https://github.com/esphome/ESPAsyncWebServer
+architectures=esp8266, esp32
+depends=AsyncTCP, ESPAsyncTCP

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -186,7 +186,7 @@ void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage)
     return;
   }
   if(_messageQueue.length() >= SSE_MAX_QUEUED_MESSAGES){
-      ets_printf("ERROR: Too many messages queued\n");
+      ESP_LOGE("ESPAsyncWebServer", "AsyncEventSource: Too many messages queued");
       delete dataMessage;
   } else {
       _messageQueue.add(dataMessage);

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -546,7 +546,7 @@ void AsyncWebSocketClient::_queueMessage(AsyncWebSocketMessage *dataMessage){
     return;
   }
   if(_messageQueue.length() >= WS_MAX_QUEUED_MESSAGES){
-      ets_printf("ERROR: Too many messages queued\n");
+      ESP_LOGE("ESPAsyncWebServer", "AsyncWebSocket: Too many messages queued");
       delete dataMessage;
   } else {
       _messageQueue.add(dataMessage);

--- a/src/WebAuthentication.cpp
+++ b/src/WebAuthentication.cpp
@@ -27,6 +27,15 @@
 #endif
 
 
+#if MBEDTLS_MAJOR_VERSION < 3
+// Compatibility with older versions of mbedTLS
+// https://github.com/Mbed-TLS/mbedtls/blob/development/docs/3.0-migration-guide.md
+#define mbedtls_md5_starts_ret mbedtls_md5_starts
+#define mbedtls_md5_update_ret mbedtls_md5_update
+#define mbedtls_md5_finish_ret mbedtls_md5_finish
+#endif
+
+
 // Basic Auth hash = base64("username:password")
 
 bool checkBasicAuthentication(const char * hash, const char * username, const char * password){


### PR DESCRIPTION
The newest release of the ESP32 core for Arduino (3.x) comes with [some breaking changes](https://docs.espressif.com/projects/arduino-esp32/en/latest/migration_guides/2.x_to_3.0.html). Among other things, the underlying ESP-IDF updated from 4.4 to 5.1, in turn [updating mbed TLS from v2.28.x to v3.x](https://github.com/espressif/mbedtls/wiki#mbed-tls-support-in-esp-idf), which [has its own breaking changes](https://github.com/espressif/mbedtls/blob/9bb5effc3298265f829878825d9bd38478e67514/docs/3.0-migration-guide.md).

In particular, [`mbedtlx_md5_{starts,update,finish}_ret` were renamed to the same name without `_ret`](https://github.com/espressif/mbedtls/blob/9bb5effc3298265f829878825d9bd38478e67514/docs/3.0-migration-guide.md#deprecated-functions-were-removed-from-hashing-modules), which affects this code. This change adds conditional `#define`s and should work on either version.

Also, the `ets_printf` logging utility seems to have gone away; I can't actually find its previous documentation. I replaced some calls with the documented `ESP_LOGE` macro.

Finally, per https://github.com/esphome/ESPAsyncWebServer/issues/34 I incorporated a `library.properties` file, without which it would be hard for me to test these changes.