### PR TITLE
Bugfix: AsyncEventSource writes multiple events per tcp send, including partial events that straddle buffers; Improvement: don't hold onto event items until ack, immediately remove them from queue

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -124,7 +124,11 @@ AsyncEventSourceMessage::~AsyncEventSourceMessage() {
 }
 
 size_t AsyncEventSourceMessage::ack(size_t len, uint32_t time) {
-  (void)time;
+    (void)time;
+    return ack(len);
+}
+
+size_t AsyncEventSourceMessage::ack(size_t len) {
   // If the whole message is now acked...
   if(_acked + len > _len){
      // Return the number of extra bytes acked (they will be carried on to the next message)
@@ -137,16 +141,21 @@ size_t AsyncEventSourceMessage::ack(size_t len, uint32_t time) {
   return 0;
 }
 
-size_t AsyncEventSourceMessage::send(AsyncClient *client) {
-  if (!client->canSend())
+size_t AsyncEventSourceMessage::write_buffer(AsyncClient *client) {
+  if (!client->canSend() || client->space() <= 0)
     return 0;
   const size_t len = _len - _sent;
   if(client->space() < len){
-    return 0;
+    len = client->space();
   }
-  size_t sent = client->add((const char *)_data, len);
-  client->send();
+  size_t sent = client->add((const char *)_data + _sent, len);
   _sent += sent;
+  return sent;
+}
+
+size_t AsyncEventSourceMessage::send(AsyncClient *client) {
+  size_t sent = write_buffer(client);
+  client->send();
   return sent;
 }
 
@@ -171,6 +180,8 @@ AsyncEventSourceClient::AsyncEventSourceClient(AsyncWebServerRequest *request, A
 
   _server->_addClient(this);
   delete request;
+
+  _client->setNoDelay(true);
 }
 
 AsyncEventSourceClient::~AsyncEventSourceClient(){
@@ -185,8 +196,9 @@ void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage)
     delete dataMessage;
     return;
   }
+
   if(_messageQueue.length() >= SSE_MAX_QUEUED_MESSAGES){
-      ets_printf("ERROR: Too many messages queued\n");
+      ets_printf("AsyncEventSourceClient: ERROR: Queue is full, communications too slow, dropping event");
       delete dataMessage;
   } else {
       _messageQueue.add(dataMessage);
@@ -196,12 +208,6 @@ void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage)
 }
 
 void AsyncEventSourceClient::_onAck(size_t len, uint32_t time){
-  while(len && !_messageQueue.isEmpty()){
-    len = _messageQueue.front()->ack(len, time);
-    if(_messageQueue.front()->finished())
-      _messageQueue.remove(_messageQueue.front());
-  }
-
   _runQueue();
 }
 
@@ -247,14 +253,25 @@ void AsyncEventSourceClient::_runQueue(){
   this->_messageQueue_processing = true;
 #endif // ESP32
 
-  while(!_messageQueue.isEmpty() && _messageQueue.front()->finished()){
-    _messageQueue.remove(_messageQueue.front());
-  }
-
+  size_t total_bytes_written = 0;
   for(auto i = _messageQueue.begin(); i != _messageQueue.end(); ++i)
   {
-    if(!(*i)->sent())
-      (*i)->send(_client);
+    if(!(*i)->sent()) {
+      size_t bytes_written = (*i)->write_buffer(_client);
+      total_bytes_written += bytes_written;
+      if(bytes_written == 0)
+        break;
+    }
+  }
+  if(total_bytes_written > 0)
+    _client->send();
+
+  size_t len = total_bytes_written;
+  while(len && !_messageQueue.isEmpty()){
+    len = _messageQueue.front()->ack(len);
+    if(_messageQueue.front()->finished()){
+      _messageQueue.remove(_messageQueue.front());
+    }
   }
 
 #if defined(ESP32)

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -144,7 +144,7 @@ size_t AsyncEventSourceMessage::ack(size_t len) {
 size_t AsyncEventSourceMessage::write_buffer(AsyncClient *client) {
   if (!client->canSend() || client->space() <= 0)
     return 0;
-  const size_t len = _len - _sent;
+  size_t len = _len - _sent;
   if(client->space() < len){
     len = client->space();
   }

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -69,6 +69,8 @@ class AsyncEventSourceMessage {
     AsyncEventSourceMessage(const char * data, size_t len);
     ~AsyncEventSourceMessage();
     size_t ack(size_t len, uint32_t time __attribute__((unused)));
+    size_t ack(size_t len);
+    size_t write_buffer(AsyncClient *client);
     size_t send(AsyncClient *client);
     bool finished(){ return _acked == _len; }
     bool sent() { return _sent == _len; }


### PR DESCRIPTION
Bugfix: AsyncEventSource writes multiple events per tcp send, including partial events that straddle buffers
----------

On line 148 in the diff, client->send() was being called before additional events could write into the tcp client send buffer.  Once send is initiated, client->canSend() will return false preventing more events from being written.  (edit: on the 8266, see update section for esp32 behavior)  This resulted in only a single event per packet to be sent. 

Because an ack must be received before canSend will become true again (the buffer must be held onto in case a tcp retry is needed) this resulted in (observed with WireShark) only one event every 70-80ms -- ESP-01: 20ms to send another packet after ack received, windows: 40-50ms to send an ack back after receiving a packet due to the equivalent of 'nagle algorithm' for acks on the receive side

The call to _client->send(); is now on line 267 after as many events have been written to the client tcp send buffer as will fit (including partial events to fully maximize the throughput).  This improves event-throughput-per-ack by as much as 10-15x in some cases but probably around 5x in general (it varies with event size) based on the log output I was observing during testing.  (edit: on the 8266, see update section for esp32 behavior)

I call this a bugfix since clearly the code was *trying* to add multiple events per send, that appears to be the original author's intent, it was just failing to do so because client->send() was called after the first event was written and that locked the tcp send buffer against further writes.  (edit: on the 8266, see update section for esp32 behavior)

Improvement: don't hold onto event items until ack, immediately remove them from queue once (fully) written into the tcp send buffer
--------

This code was holding onto the queued events until an ack came back, even after they were written to the tcp send buffer.  There is no need to do so, the tcp send buffer is retained by the client for retries (why things were stalling out in the first place) so this just results in the data being duplicated in memory needlessly.  Removing them from the queue immediately after write to the client tcp send buffer also makes those queue slots available for new incoming events, potentially reducing the number of dropped events during event bursts, or just lowering memory usage otherwise.

Practical effects for esphome:
---------
1) Logs will show up much more quickly in the web_server dashboard
2) Less logs and events will be dropped en-route to the dashboard in general, this means you are less likely to get the "funky dashboard" effect where bits are randomly missing or not all of your sensors show up - the initial dashboard load is particularly event-bursty as all sensors are enumerated and written so that the javascript can build the UI
3) Less likely that sensor updates will be entirely dropped leaving parts of the dash UX static if you have a lot of sensors publishing, or a lot of log lines filling up the event queue.

And just in general:
1) It's now possible to send a single event larger than the tcp send buffer size since parts of an event can be written iteratively until complete.  Not sure why you'd want to do such a thing, but such an event will no-longer stall the event source completely and unrecoverably.
2) Lower CPU usage due to batching (less packets generated).
3) Potentially lower memory consumption due to earlier queue item discard.

Update for ESP32 chips:
---------
I'm now looking at an ESP-C3 on wireshark and can see that the different TCP library used on ESP32s vs ESP8266s does allow the AsyncEventSource to write multiple events to the tcp send buffer even after a send has been initiated.  This more advanced TCP stack will simply send additional packets out, processing the send-buffer piecewise as it is written.  The act of sending packets incrementally as each event is written will actually reach the receiving side's threshold for sending an ACK (or does on Windows anyway), even with delayed ack in effect.  This additional capability and coincidental effect on ack frequency is probably why no-one noticed this undesirable behavior earlier.  (Plus performance issues on an 8266 are likely to be blamed on the slower core and dismissed.)

The change in this PR is still an improvement on the ESP32 stack, there is still an increase in event throughput, more efficient use of the full length of the send buffer, less CPU usage due to the batching, and less memory usage due to discarding queue items early, but the improvement will be less noticeable since the improved behavior and capabilities of the new TCP stack mitigated the implementation flaws in AsyncEventSource to a large degree - making it only display truly degenerate behavior on the 8266 class chips.

Additionally, on the 32, since the send buffer is larger than the MTU of ~1400, in case of high event load two packets will still be sent, thus still bypassing delayed ack.  Even in case of lower event load, additional events will still generate additional packets (on addition loop()s) with the upgraded tcp library's ability to process the send buffer incrementally, thus also bypassing delayed ack.  So this PR won't cause any regression in behavior in that regard due to the "batching effect".

I haven't dug into the TCP libraries themselves to see if this capability to incrementally process the send buffer and send additional packets as new writes happen could be added to the older stack used on the 8266.  The improvement in this PR is probably "good enough" in working around the limitation, the 8266 isn't recommended for new designs at this point, and going that low into the network stack carries higher risk of regression while this change is relatively straightforward.