### PR TITLE
Increased the header buffer to 8000 for larger redirect URLs

### DIFF
--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -130,7 +130,7 @@ String AsyncWebServerResponse::_assembleHead(uint8_t version){
       addHeader("Transfer-Encoding","chunked");
   }
   String out = String();
-  int bufSize = 300;
+  int bufSize = 8000;
   char buf[bufSize];
 
   snprintf(buf, bufSize, "HTTP/1.%d %d %s\r\n", version, _code, _responseCodeToString(_code));


### PR DESCRIPTION
I ran into an issue with larger redirect URLs.
My URL was ~ 360 characters long and I noticed it was concatenated to 300 characters.
This Pull request increases the buffer size for headers from 300 to 8000 characters.
8000 because of the recommendation in the RFC (https://www.rfc-editor.org/rfc/rfc9110.html#section-4.1): 
> It is RECOMMENDED that all senders and recipients support, at a minimum, URIs with lengths of 8000 octets in protocol elements.